### PR TITLE
ci: 🎡 Locked robot versions for toml and requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2024.2.1.3"
+robotpy_version = "2024.2.1.1"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2024.2.1.1"
+robotpy_version = "2024.2.1.3"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,11 @@ modulegraph
 flake8
 coverage
 wheel
-robotpy[all]
+robotpy[all]==2024.2.1.1
 pyntcore==2024.*
 
 #robotpy[ctre,navx,rev,sim,pathplannerlib,photonvision,playingwithfusion] == 2024.*
 
 # If installed on OSX (joystick support) it seems to fail?
-pyfrc == 2024.*
+pyfrc == 2024.0.1
 robotpy-halsim-gui


### PR DESCRIPTION

Changelog

Locked the robotpy versions
What?

Set explicit robotpy versions to 2024.2.1.1 for deployment and requirements
Why?

It's late enough in the season that we should want explicit versions
