### PR TITLE
Shooter recalibrate

### DIFF
--- a/commands/shortyShooter.py
+++ b/commands/shortyShooter.py
@@ -10,7 +10,10 @@ class ShooterCommand(commands2.CommandBase):
                  intaking : typing.Callable[[], bool],
                  outaking : typing.Callable[[], bool],
                  shooterSpeed : typing.Callable[[], float],
-                 pivotToggle: typing.Callable[[], bool]):
+                 pivotToggle: typing.Callable[[], bool],
+                 climbPos : typing.Callable[[], bool],
+                 manualControl : typing.Callable[[], bool],
+                 manualInput : typing.Callable[[], float]):
         super().__init__()
 
         self.shooter = shooter
@@ -22,6 +25,11 @@ class ShooterCommand(commands2.CommandBase):
         self.pivot = pivot
         self.pivotLoad = True
         self.pivot.enable()
+
+        self.climbPos = climbPos
+
+        self.manualControl = manualControl
+        self.manualInput = manualInput
 
         self.addRequirements(self.shooter, self.pivot)
 
@@ -35,6 +43,8 @@ class ShooterCommand(commands2.CommandBase):
 
         self.shooter.runShooters(self.shooterSpeed())
 
+        self.pivot.checkManualControl(self.manualControl(), self.manualInput())
+
         if(self.pivotToggle()):
             if self.pivotLoad:
                 self.pivotLoad = False
@@ -42,3 +52,7 @@ class ShooterCommand(commands2.CommandBase):
             else:
                 self.pivotLoad = True
                 self.pivot.setLoading()
+
+        if(self.climbPos()):
+            self.pivot.setClimb()
+

--- a/commands/shortyShooter.py
+++ b/commands/shortyShooter.py
@@ -43,9 +43,14 @@ class ShooterCommand(commands2.CommandBase):
 
         self.shooter.runShooters(self.shooterSpeed())
 
-        self.pivot.checkManualControl(self.manualControl(), self.manualInput())
+        if(self.manualControl()):
+            self.pivot.disable()
+            self.pivot.runPivot(0.2 * round(self.manualInput()))
+        elif(self.manualControl() and not self.pivot.isEnabled):
+            self.pivot.runPivot(0)
 
         if(self.pivotToggle()):
+            self.pivot.enable()
             if self.pivotLoad:
                 self.pivotLoad = False
                 self.pivot.setAmp()
@@ -54,5 +59,5 @@ class ShooterCommand(commands2.CommandBase):
                 self.pivot.setLoading()
 
         if(self.climbPos()):
+            self.pivot.enable()
             self.pivot.setClimb()
-

--- a/robotswerve.py
+++ b/robotswerve.py
@@ -84,9 +84,9 @@ class RobotSwerve:
             lambda: self.mechController.getBButton(),
             lambda: self.mechController.getRightTriggerAxis(),
             self.mechController.getYButtonPressed,
+            self.mechController.getXButtonPressed,
             self.mechController.getLeftBumper,
-            self.mechController.getLeftY,
-            self.mechController.getXButtonPressed
+            self.mechController.getLeftY
         ))
 
         CameraServer.launch()

--- a/robotswerve.py
+++ b/robotswerve.py
@@ -83,8 +83,11 @@ class RobotSwerve:
             lambda: self.mechController.getRightBumper(),
             lambda: self.mechController.getBButton(),
             lambda: self.mechController.getRightTriggerAxis(),
-            self.mechController.getYButtonPressed
-            ))
+            self.mechController.getYButtonPressed,
+            self.mechController.getLeftBumper,
+            self.mechController.getLeftY,
+            self.mechController.getXButtonPressed
+        ))
 
         CameraServer.launch()
 

--- a/subsystem/sparkyIntakePivot.py
+++ b/subsystem/sparkyIntakePivot.py
@@ -11,7 +11,7 @@ class IntakePivot(commands2.PIDSubsystem):
     kRolloverDeadZoneDeg = 340
     def __init__(self) -> None:
         self.pivotMotor = rev.CANSparkMax(22, rev.CANSparkLowLevel.MotorType.kBrushless)
-        self.pivotMotor.setIdleMode(rev.CANSparkMax.IdleMode.kBrake)
+        self.pivotMotor.setIdleMode(rev.CANSparkMax.IdleMode.kCoast)
         self.pivotMotor.setInverted(False)
 
         self.pivotRelEncoder = self.pivotMotor.getEncoder(rev.SparkRelativeEncoder.Type.kHallSensor)

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -28,6 +28,8 @@ class ShooterPivot(commands2.PIDSubsystem):
         self.zeroed = False
         self.zeroing = False
 
+        self.manualControl = False
+
     def runPivot(self, speed : float):
         self.pivotMotor.set(speed)
         wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
@@ -40,7 +42,10 @@ class ShooterPivot(commands2.PIDSubsystem):
         return
 
     def useOutput(self, output: float, setpoint: float):
-
+        if(self.manualControl): 
+            self.controlManually()
+            return
+        
         zeroing = self.zeroing
         #Do not use output until zeroed
         if not self.zeroed:
@@ -92,3 +97,14 @@ class ShooterPivot(commands2.PIDSubsystem):
     #sets amp angle
     def setAmp(self):
         self.setSetpoint(0.4)
+
+    def setClimb(self):
+        self.setSetpoint(0.1)
+
+    def controlManually(self):
+        self.manualControl = True
+        self.pivotMotor.set(0.2 * self.manualDirection)
+
+    def checkManualControl(self, control : bool, direction : float):
+        self.manualControl = control
+        self.manualDirection = direction

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -86,7 +86,6 @@ class ShooterPivot(commands2.PIDSubsystem):
         wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
         
         if not self.reverseLimit.get():
-            #print(f"moving {self.getPosition()}")
             self.pivotMotor.set(-speed)
             wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
             return False

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -31,7 +31,6 @@ class ShooterPivot(commands2.PIDSubsystem):
 
     def runPivot(self, speed : float):
         self.pivotMotor.set(speed)
-        #wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
 
     def getMeasurement(self):
         return -self.encoder.getPosition()

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -87,7 +87,6 @@ class ShooterPivot(commands2.PIDSubsystem):
         
         if not self.reverseLimit.get():
             self.pivotMotor.set(-speed)
-            wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
             return False
         else:
             #print(f"Done {self.getPosition()}")

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -90,7 +90,6 @@ class ShooterPivot(commands2.PIDSubsystem):
             return False
         else:
             self.pivotMotor.set(0.0)
-            wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
             return True
 
     #sets loading angle

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -80,7 +80,6 @@ class ShooterPivot(commands2.PIDSubsystem):
             self.zeroed = True
             self.pivotMotor.set(0.0)
             self.encoder.setPosition(0)
-            wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
             return True
 
     def maxPivot(self, speed : float = 0.2):

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -89,7 +89,6 @@ class ShooterPivot(commands2.PIDSubsystem):
             self.pivotMotor.set(-speed)
             return False
         else:
-            #print(f"Done {self.getPosition()}")
             self.pivotMotor.set(0.0)
             wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
             return True

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -83,6 +83,8 @@ class ShooterPivot(commands2.PIDSubsystem):
             return True
 
     def maxPivot(self, speed : float = 0.2):
+        wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
+        
         if not self.reverseLimit.get():
             #print(f"moving {self.getPosition()}")
             self.pivotMotor.set(-speed)

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -39,15 +39,6 @@ class ShooterPivot(commands2.PIDSubsystem):
         return
 
     def useOutput(self, output: float, setpoint: float):
-        """
-        if(self.manualControl): 
-            self.controlManually()
-            return
-        
-        if(self.maintainPosition):
-            return
-        """
-        
         zeroing = self.zeroing
         #Do not use output until zeroed
         if not self.zeroed:

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -16,6 +16,7 @@ class ShooterPivot(commands2.PIDSubsystem):
         self.pivotMotor.setInverted(False)
         self.encoder = self.pivotMotor.getEncoder()
         #scaled to 0..1 = forward - end limit
+        #80:1 use 1/73.38 100:1 use 88.056
         self.encoder.setPositionConversionFactor(1/88.056)
 
         #get limits

--- a/subsystem/sparkyShooterPivot.py
+++ b/subsystem/sparkyShooterPivot.py
@@ -74,7 +74,6 @@ class ShooterPivot(commands2.PIDSubsystem):
         if not self.forwardLimit.get():
             self.zeroed = False
             self.pivotMotor.set(speed)
-            wpilib.SmartDashboard.putNumber("Shooter pos", self.encoder.getPosition())
             return False
         else:
             self.zeroing = False


### PR DESCRIPTION
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Steps to Test
Hold the left bumper on the Xbox controller to enable manual movement. While holding the left bumper use the right joystick Y axis to move the shooter. Click X to move to Climb position.

## Changelog
The drive team wanted manual control for hanging on the chain. They also wanted a position slightly above zero so the chain doesn't hit the limit switch.

## Why?

We need it to climb, plus drive team demanded it.




